### PR TITLE
Expose resources directory to user

### DIFF
--- a/app/src/main/java/utils/MyApp.kt
+++ b/app/src/main/java/utils/MyApp.kt
@@ -24,11 +24,11 @@ class MyApp : Application() {
         Constants.USER_FILE_STORAGE = Environment.getExternalStorageDirectory().toString() + "/$slug/"
         Constants.USER_CONFIG = "${Constants.USER_FILE_STORAGE}/config"
         Constants.USER_OPENMW_CFG =  "${Constants.USER_CONFIG}/openmw.cfg"
+        Constants.RESOURCES = "${Constants.USER_FILE_STORAGE}/resources"
         Constants.SETTINGS_DEFAULT_CFG = File(filesDir, "config/settings-default.cfg").absolutePath
         Constants.OPENMW_CFG = File(filesDir, "config/openmw.cfg").absolutePath
         Constants.OPENMW_BASE_CFG = File(filesDir, "config/openmw.base.cfg").absolutePath
         Constants.OPENMW_FALLBACK_CFG = File(filesDir, "config/openmw.fallback.cfg").absolutePath
-        Constants.RESOURCES = File(filesDir, "resources").absolutePath
         Constants.GLOBAL_CONFIG = File(filesDir, "config").absolutePath
         Constants.VERSION_STAMP = File(filesDir, "stamp").absolutePath
 


### PR DESCRIPTION
The reasoning behind this is to allow users to modify shaders and/or mygui resource files to their linking (some mods use custom shaders specifically for openmw)